### PR TITLE
update org exceed-api-quota after stats api calls

### DIFF
--- a/dtable_events/api_calls/api_calls_counter.py
+++ b/dtable_events/api_calls/api_calls_counter.py
@@ -10,9 +10,11 @@ from apscheduler.schedulers.blocking import BlockingScheduler
 from dateutil import parser, relativedelta
 from sqlalchemy import text
 
+from dtable_events.app.config import DTABLE_WEB_SERVICE_URL
 from dtable_events.app.event_redis import RedisClient
 from dtable_events.db import init_db_session_class
 from dtable_events.utils import uuid_str_to_32_chars
+from dtable_events.utils.dtable_web_api import DTableWebAPI
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +98,15 @@ class APICallsCounter:
             db_session.execute(text(sql))
             db_session.commit()
 
+        # update exceed status
+        org_ids = list(org_counts_dict.keys())
+        if org_ids:
+            dtable_web_api = DTableWebAPI(DTABLE_WEB_SERVICE_URL)
+            try:
+                dtable_web_api.internal_update_exceed_api_quota(month, org_ids)
+            except Exception as e:
+                logger.exception('update org_ids: %s error: %s', org_ids, e)
+
     def count_api_calls(self, info, db_session):
         component = info.get('component')
         try:
@@ -147,6 +158,31 @@ class APICallsCounter:
 
         sched.start()
 
+    def reset(self):
+        logger.info('Starting schedule reset api calls exceed status...')
+        sched = BlockingScheduler()
+        # fire at 0 o'clock in every day of week
+        @sched.scheduled_job('cron', month='*', day='1', day_of_week='*', hour='0', misfire_grace_time=600)
+        def timed_job():
+            session = self._db_session_class()
+            sql = "DELETE FROM `exceed_api_quota_teams`"
+            logger.info('Reset exceed_api_quota_teams now: %s', datetime.now())
+            try:
+                session.execute(text(sql))
+                session.commit()
+            except Exception as e:
+                logger.exception('reset api calls exceed status error: %s', e)
+            finally:
+                session.close()
+
+            try:
+                self._redis_client.connection.publish('exceed_api_quota', json.dumps({'changed': True}))
+            except Exception as e:
+                logger.exception('publish exceed_api_quota error: %s', e)
+
+        sched.start()
+
     def start(self):
         Thread(target=self.count, daemon=True).start()
         Thread(target=self.clean, daemon=True).start()
+        Thread(target=self.reset, daemon=True).start()

--- a/dtable_events/api_calls/api_calls_counter.py
+++ b/dtable_events/api_calls/api_calls_counter.py
@@ -105,7 +105,7 @@ class APICallsCounter:
             try:
                 dtable_web_api.internal_update_exceed_api_quota(month, org_ids)
             except Exception as e:
-                logger.exception('update org_ids: %s error: %s', org_ids, e)
+                logger.exception('update exceed api quota error: %s', e)
 
     def count_api_calls(self, info, db_session):
         component = info.get('component')
@@ -166,7 +166,7 @@ class APICallsCounter:
         def timed_job():
             session = self._db_session_class()
             sql = "DELETE FROM `exceed_api_quota_teams`"
-            logger.info('Reset exceed_api_quota_teams now: %s', datetime.now())
+            logger.info('Start to reset exceed_api_quota_teams')
             try:
                 session.execute(text(sql))
                 session.commit()

--- a/dtable_events/tests/sql/test_reference.py
+++ b/dtable_events/tests/sql/test_reference.py
@@ -13,8 +13,8 @@ def get_expected_sql_for_modifier(filter_modifier, column_name):
         end_date = today + timedelta(days=14 - week_day)
 
     start_date = start_date.strftime("%Y-%m-%d")
-    end_date = end_date.strftime("%Y-%m-%d")
-    expected_sql = "SELECT * FROM `Table1` WHERE `%s` >= '%s' and `%s` <= '%s' LIMIT 0, 100" % (column_name, start_date, column_name, end_date)
+    end_date = (end_date + timedelta(days=1)).strftime("%Y-%m-%d")
+    expected_sql = "SELECT * FROM `Table1` WHERE `%s` >= '%s' and `%s` < '%s' LIMIT 0, 100" % (column_name, start_date, column_name, end_date)
     return expected_sql
 
 
@@ -255,7 +255,7 @@ TEST_CONDITIONS = [
             "filter_predicate": 'And',
             "sorts":[],
         },
-        "expected_sql": "SELECT * FROM `Table1` WHERE (`Time2d` >= '2021-12-21' or `Time2d` <= '2021-12-19' or `Time2d` is null) LIMIT 0, 100",
+        "expected_sql": "SELECT * FROM `Table1` WHERE (`Time2d` >= '2021-12-21' or `Time2d` < '2021-12-20' or `Time2d` is null) LIMIT 0, 100",
         "by_group": False,
     },
     {
@@ -266,7 +266,7 @@ TEST_CONDITIONS = [
             "filter_predicate": 'And',
             "sorts":[],
         },
-        "expected_sql": "SELECT * FROM `Table1` WHERE `createTime` < '2021-12-21' and `createTime` is not null LIMIT 0, 100",
+        "expected_sql": "SELECT * FROM `Table1` WHERE `createTime` < '2021-12-21T00:00:00.000000+00:00' and `createTime` is not null LIMIT 0, 100",
         "by_group": False,
     },
     {
@@ -277,7 +277,7 @@ TEST_CONDITIONS = [
             "filter_predicate": 'And',
             "sorts":[],
         },
-        "expected_sql": "SELECT * FROM `Table1` WHERE `createTime` >= '2021-12-20' and `createTime` is not null LIMIT 0, 100",
+        "expected_sql": "SELECT * FROM `Table1` WHERE `createTime` >= '2021-12-20T00:00:00.000000+00:00' and `createTime` is not null LIMIT 0, 100",
         "by_group": False,
     },
     {
@@ -288,7 +288,7 @@ TEST_CONDITIONS = [
             "filter_predicate": 'And',
             "sorts":[],
         },
-        "expected_sql": "SELECT * FROM `Table1` WHERE `modifyTime` >= '2021-12-21' and `modifyTime` is not null LIMIT 0, 100",
+        "expected_sql": "SELECT * FROM `Table1` WHERE `modifyTime` >= '2021-12-21T00:00:00.000000+00:00' and `modifyTime` is not null LIMIT 0, 100",
         "by_group": False,
     },
 
@@ -561,7 +561,7 @@ TEST_CONDITIONS = [
             "filter_predicate": 'And',
             "sorts":[],
         },
-        "expected_sql":"SELECT * FROM `Table1` WHERE `名称` = 'LINK' And `AutoNo` ilike '%NO%' And `rate` > 6 And `Mul` in ('aa', 'bb', 'cc', 'dd') And `modifyTime` >= '2021-12-21' and `modifyTime` is not null And `Sing` not in ('a', 'b', 'c') LIMIT 0, 100",
+        "expected_sql":"SELECT * FROM `Table1` WHERE `名称` = 'LINK' And `AutoNo` ilike '%NO%' And `rate` > 6 And `Mul` in ('aa', 'bb', 'cc', 'dd') And `modifyTime` >= '2021-12-21T00:00:00.000000+00:00' and `modifyTime` is not null And `Sing` not in ('a', 'b', 'c') LIMIT 0, 100",
         "by_group": False,
     },
 
@@ -594,7 +594,7 @@ TEST_CONDITIONS = [
             "limit": 500
         },
         "by_group": True,
-        "expected_sql":"SELECT * FROM `Table1` WHERE (`名称` = 'LINK' And `AutoNo` ilike '%NO%') Or (`rate` > 6 Or `Mul` in ('aa', 'bb', 'cc', 'dd') Or `modifyTime` >= '2021-12-21' and `modifyTime` is not null) ORDER BY `名称` DESC, `AutoNo` ASC LIMIT 0, 500"
+        "expected_sql":"SELECT * FROM `Table1` WHERE (`名称` = 'LINK' And `AutoNo` ilike '%NO%') Or (`rate` > 6 Or `Mul` in ('aa', 'bb', 'cc', 'dd') Or `modifyTime` >= '2021-12-21T00:00:00.000000+00:00' and `modifyTime` is not null) ORDER BY `名称` DESC, `AutoNo` ASC LIMIT 0, 500"
     },
 
     # Not group, column not found raise Exception

--- a/dtable_events/utils/dtable_web_api.py
+++ b/dtable_events/utils/dtable_web_api.py
@@ -211,3 +211,19 @@ class DTableWebAPI:
         header_token = 'Token ' + jwt.encode(payload, DTABLE_PRIVATE_KEY, 'HS256')
         resp = requests.post(url, data=data, headers={'Authorization': header_token}, timeout=30)
         return parse_response(resp)
+
+    def internal_update_exceed_api_quota(self, month, org_ids):
+        logger.debug('internal update exeed api quota month: %s org_ids: %s', month, org_ids)
+        url = '%(server_url)s/api/v2.1/internal/update-exceed-api-quota/' % {
+            'server_url': self.dtable_web_service_url
+        }
+        data = {
+            'org_ids': org_ids,
+            'month': month
+        }
+        payload = {
+            'exp': int(time.time()) + 60
+        }
+        header_token = 'Token ' + jwt.encode(payload, DTABLE_PRIVATE_KEY, 'HS256')
+        resp = requests.post(url, json=data, headers={'Authorization': header_token}, timeout=30)
+        return parse_response(resp)

--- a/dtable_events/utils/dtable_web_api.py
+++ b/dtable_events/utils/dtable_web_api.py
@@ -213,7 +213,7 @@ class DTableWebAPI:
         return parse_response(resp)
 
     def internal_update_exceed_api_quota(self, month, org_ids):
-        logger.debug('internal update exeed api quota month: %s org_ids: %s', month, org_ids)
+        logger.debug('internal update exeed api quota for month %s, org_ids are %s', month, org_ids)
         url = '%(server_url)s/api/v2.1/internal/update-exceed-api-quota/' % {
             'server_url': self.dtable_web_service_url
         }


### PR DESCRIPTION
- call dtable-web to update exceed-api-quota after stats apis calls
- clean exceed_api_quota_teams at 00:00 at 1st every month