### PR TITLE
fix: prevent duplicate WHERE clause in filter SQL generation

### DIFF
--- a/dtable_events/tests/sql/update_filter_sql.py
+++ b/dtable_events/tests/sql/update_filter_sql.py
@@ -1,0 +1,71 @@
+import unittest
+import os
+import sys
+d = os.path.dirname
+sys.path.append(d(d(d(d(__file__)))))
+from dtable_events.utils.sql_generator import StatisticSQLGenerator
+
+
+def _make_generator(filter_sql=''):
+    gen = StatisticSQLGenerator.__new__(StatisticSQLGenerator)
+    gen.filter_sql = filter_sql
+    return gen
+
+
+class UpdateFilterSqlTest(unittest.TestCase):
+
+    def setUp(self):
+        self.maxDiff = None
+        self.col_a = {'name': 'colA', 'type': 'text'}
+        self.col_b = {'name': 'colB', 'type': 'number'}
+
+    def test_empty_include_empty(self):
+        gen = _make_generator('')
+        gen._update_filter_sql(True, self.col_a)
+        self.assertEqual(gen.filter_sql, '')
+
+    def test_empty_not_include_empty(self):
+        gen = _make_generator('')
+        gen._update_filter_sql(False, self.col_a)
+        self.assertEqual(gen.filter_sql, 'WHERE `colA` is not null')
+
+    def test_first_call_include_empty(self):
+        gen = _make_generator('`colA` = "x"')
+        gen._update_filter_sql(True, self.col_a)
+        self.assertEqual(gen.filter_sql, 'WHERE `colA` = "x"')
+
+    def test_first_call_not_include_empty(self):
+        gen = _make_generator('`colA` = "x"')
+        gen._update_filter_sql(False, self.col_b)
+        self.assertEqual(gen.filter_sql, 'WHERE `colB` is not null AND (`colA` = "x")')
+
+    def test_repeated_call_include_empty(self):
+        gen = _make_generator('WHERE `colA` = "x"')
+        gen._update_filter_sql(True, self.col_a)
+        self.assertEqual(gen.filter_sql, 'WHERE `colA` = "x"')
+
+    def test_repeated_call_not_include_empty(self):
+        gen = _make_generator('WHERE `colA` = "x"')
+        gen._update_filter_sql(False, self.col_b)
+        self.assertEqual(gen.filter_sql, 'WHERE `colB` is not null AND (`colA` = "x")')
+
+    def test_repeated_call_different_column(self):
+        gen = _make_generator('WHERE `colA` is not null AND (`colB` = 1)')
+        gen._update_filter_sql(False, self.col_a)
+        self.assertEqual(gen.filter_sql, 'WHERE `colA` is not null AND (`colA` is not null AND (`colB` = 1))')
+
+    def test_idempotent_include_empty(self):
+        gen = _make_generator('`colA` = "x"')
+        gen._update_filter_sql(True, self.col_a)
+        gen._update_filter_sql(True, self.col_a)
+        self.assertEqual(gen.filter_sql, 'WHERE `colA` = "x"')
+
+    def test_no_duplicate_where_prefix(self):
+        gen = _make_generator('`colA` = "x"')
+        gen._update_filter_sql(False, self.col_b)
+        gen._update_filter_sql(False, self.col_b)
+        self.assertFalse(gen.filter_sql.startswith('WHERE WHERE'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dtable_events/utils/sql_generator.py
+++ b/dtable_events/utils/sql_generator.py
@@ -1469,6 +1469,11 @@ class StatisticSQLGenerator(object):
         return f"{order_header} {', '.join(sort_sql)}"
 
     def _update_filter_sql(self, x_axis_include_empty, x_axis_column):
+        # avoid adding the WHERE clause repeatedly when this method is called
+        # more than once
+        if self.filter_sql and self.filter_sql.startswith('WHERE'):
+            return
+
         if x_axis_include_empty:
             if self.filter_sql:
                 self.filter_sql = 'WHERE %s' % self.filter_sql

--- a/dtable_events/utils/sql_generator.py
+++ b/dtable_events/utils/sql_generator.py
@@ -1469,10 +1469,8 @@ class StatisticSQLGenerator(object):
         return f"{order_header} {', '.join(sort_sql)}"
 
     def _update_filter_sql(self, x_axis_include_empty, x_axis_column):
-        # avoid adding the WHERE clause repeatedly when this method is called
-        # more than once
         if self.filter_sql and self.filter_sql.startswith('WHERE'):
-            return
+            self.filter_sql = self.filter_sql[len('WHERE'):].strip()
 
         if x_axis_include_empty:
             if self.filter_sql:


### PR DESCRIPTION
Added guard to prevent adding WHERE clause multiple times when _update_filter_sql is called repeatedly in StatisticSQLGenerator.